### PR TITLE
Fix Confluence pagination base URL handling

### DIFF
--- a/src/trailblazer/adapters/confluence_api.py
+++ b/src/trailblazer/adapters/confluence_api.py
@@ -43,7 +43,7 @@ class ConfluenceClient:
             else:
                 # Handle relative URLs properly - nxt should be like "/wiki/api/v2/pages?..."
                 # Don't double-add /wiki since it's already in the relative path
-                base_without_wiki = self.api_base.replace("/wiki", "")
+                base_without_wiki = self.api_base.removesuffix("/wiki")
                 return urljoin(base_without_wiki + "/", nxt.lstrip("/"))
 
         # fallback: Link header
@@ -56,7 +56,7 @@ class ConfluenceClient:
                     return url
                 else:
                     # Handle relative URLs properly
-                    base_without_wiki = self.api_base.replace("/wiki", "")
+                    base_without_wiki = self.api_base.removesuffix("/wiki")
                     return urljoin(base_without_wiki + "/", url.lstrip("/"))
         return None
 

--- a/tests/pipeline/steps/ingest/test_confluence_client_pagination.py
+++ b/tests/pipeline/steps/ingest/test_confluence_client_pagination.py
@@ -74,6 +74,49 @@ def test_paginate_with_links_next(mock_http_client):
     assert second_call[1]["params"] is None
 
 
+def test_paginate_with_links_next_wiki_in_hostname(mock_http_client):
+    """Ensure pagination works when hostname already contains 'wiki'."""
+
+    client = ConfluenceClient(
+        base_url="https://wiki.example.com/wiki",
+        email="test@example.com",
+        token="dummy",
+    )
+    client._client = mock_http_client
+
+    response1 = Mock()
+    response1.raise_for_status.return_value = None
+    response1.json.return_value = {
+        "results": [
+            {"id": "1", "title": "Page 1"},
+        ],
+        "_links": {"next": "/api/v2/pages?cursor=next1"},
+    }
+    response1.headers = {}
+
+    response2 = Mock()
+    response2.raise_for_status.return_value = None
+    response2.json.return_value = {
+        "results": [
+            {"id": "2", "title": "Page 2"},
+        ],
+        "_links": {},
+    }
+    response2.headers = {}
+
+    mock_http_client.get.side_effect = [response1, response2]
+
+    results = list(client._paginate("/api/v2/pages", {"limit": 1}))
+
+    assert len(results) == EXPECTED_COUNT_2
+    assert results[0]["id"] == "1"
+    assert results[1]["id"] == "2"
+
+    second_call = mock_http_client.get.call_args_list[1]
+    assert second_call[0][0] == "https://wiki.example.com/api/v2/pages?cursor=next1"
+    assert second_call[1]["params"] is None
+
+
 def test_paginate_with_link_header(mock_http_client):
     """Test pagination using Link header as fallback."""
 
@@ -117,6 +160,48 @@ def test_paginate_with_link_header(mock_http_client):
     # Second call should use the URL from Link header (fixed to remove double /wiki)
     second_call = mock_http_client.get.call_args_list[1]
     assert second_call[0][0] == "https://example.atlassian.net/api/v2/pages?cursor=abc123"
+
+
+def test_paginate_with_link_header_wiki_in_hostname(mock_http_client):
+    """Ensure Link header pagination works when hostname contains 'wiki'."""
+
+    client = ConfluenceClient(
+        base_url="https://docs.wiki-hosting.net/wiki",
+        email="test@example.com",
+        token="dummy",
+    )
+    client._client = mock_http_client
+
+    response1 = Mock()
+    response1.raise_for_status.return_value = None
+    response1.json.return_value = {
+        "results": [
+            {"id": "1", "title": "Page 1"},
+        ],
+        "_links": {},
+    }
+    response1.headers = {"Link": '</api/v2/pages?cursor=next1>; rel="next"'}
+
+    response2 = Mock()
+    response2.raise_for_status.return_value = None
+    response2.json.return_value = {
+        "results": [
+            {"id": "2", "title": "Page 2"},
+        ],
+        "_links": {},
+    }
+    response2.headers = {}
+
+    mock_http_client.get.side_effect = [response1, response2]
+
+    results = list(client._paginate("/api/v2/pages", {"limit": 1}))
+
+    assert len(results) == EXPECTED_COUNT_2
+    assert results[0]["id"] == "1"
+    assert results[1]["id"] == "2"
+
+    second_call = mock_http_client.get.call_args_list[1]
+    assert second_call[0][0] == "https://docs.wiki-hosting.net/api/v2/pages?cursor=next1"
 
 
 def test_paginate_single_page(mock_http_client):


### PR DESCRIPTION
## Summary
- ensure pagination next links strip only the trailing /wiki suffix from the base URL
- add regression tests covering hostnames that already contain "wiki"

## Testing
- PYTHONPATH=src pytest tests/pipeline/steps/ingest/test_confluence_client_pagination.py

------
https://chatgpt.com/codex/tasks/task_e_6900fa9e0e3483269e2e6506d0c00cba

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix next-link URL construction to strip only the trailing "/wiki" and add tests for hostnames containing "wiki".
> 
> - **Confluence adapter**:
>   - Fix pagination URL normalization by using `removesuffix("/wiki")` when building next-page links from `_links.next` and `Link` header.
> - **Tests**:
>   - Add cases ensuring pagination works when hostname already contains `wiki` for both `_links.next` and `Link` header paths.
>   - Update assertions to verify next calls use `https://.../api/v2/pages?cursor=...` without double `/wiki`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d425fc4aecb344bb3074756cc7d1b62ac0d9b51e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->