### PR TITLE
Handle media placeholders with optional whitespace

### DIFF
--- a/src/trailblazer/pipeline/steps/retrieve/retriever.py
+++ b/src/trailblazer/pipeline/steps/retrieve/retriever.py
@@ -224,9 +224,10 @@ def pack_context(
             # Find first media placeholder
             import re
 
-            media_match = re.search(r"!\[media: ([^\]]+)\]", hit_text)
+            media_match = re.search(r"!\[media:\s*([^\]]+)\]", hit_text)
             if media_match:
-                hit_text = f"![media: {media_match.group(1)}]\n\n{hit_text}"
+                placeholder = media_match.group(0)
+                hit_text = f"{placeholder}\n\n{hit_text}"
 
         docs_seen.add(hit.doc_id)
 

--- a/tests/pipeline/steps/retrieve/test_retrieval_dense.py
+++ b/tests/pipeline/steps/retrieve/test_retrieval_dense.py
@@ -142,6 +142,46 @@ def test_pack_context_includes_media_placeholder(sample_hits):
     assert "![media: image.png]" in context_str
 
 
+def test_pack_context_inserts_media_placeholder_with_space():
+    """Test placeholder insertion when media tag includes a space."""
+    hits = [
+        SearchHit(
+            chunk_id="docspace:0000",
+            doc_id="docspace",
+            title="Doc With Space",
+            url="",
+            text_md="![media: space.png]\n\nContent",
+            score=0.5,
+            source_system="test",
+        )
+    ]
+
+    context_str, _ = pack_context(hits, max_chars=6000)
+
+    # One from original text and one prepended placeholder
+    assert context_str.count("![media: space.png]") == 2
+
+
+def test_pack_context_inserts_media_placeholder_without_space():
+    """Test placeholder insertion when media tag omits whitespace."""
+    hits = [
+        SearchHit(
+            chunk_id="docnospace:0000",
+            doc_id="docnospace",
+            title="Doc Without Space",
+            url="",
+            text_md="![media:nospace.png]\n\nContent",
+            score=0.5,
+            source_system="test",
+        )
+    ]
+
+    context_str, _ = pack_context(hits, max_chars=6000)
+
+    # One from original text and one prepended placeholder
+    assert context_str.count("![media:nospace.png]") == 2
+
+
 def test_pack_context_empty_hits():
     """Test context packing with empty hits list."""
     context_str, selected_hits = pack_context([], max_chars=1000)


### PR DESCRIPTION
## Summary
- allow context packing to recognize media placeholders with or without whitespace after the colon
- preserve the original placeholder formatting when injecting it ahead of document chunks
- add regression tests covering spaced and unspaced media placeholder tags

## Testing
- PYTHONPATH=src pytest tests/pipeline/steps/retrieve/test_retrieval_dense.py -k placeholder *(fails: requires PostgreSQL connection)*

------
https://chatgpt.com/codex/tasks/task_e_6900fa9fc57c832699bc8019aea0db02

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances context packing to detect media placeholders regardless of whitespace and prepends the original placeholder; adds tests for both cases.
> 
> - **Retrieve/Context Packing**:
>   - Update `pack_context` in `src/trailblazer/pipeline/steps/retrieve/retriever.py` to detect `![media:...]` with optional whitespace using `r"!\[media:\s*([^\]]+)\]"` and prepend the exact matched placeholder via `group(0)`.
> - **Tests**:
>   - Add tests to validate placeholder insertion for spaced (`![media: space.png]`) and unspaced (`![media:nospace.png]`) tags in `tests/pipeline/steps/retrieve/test_retrieval_dense.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f3b6fceea61d2fa69a9c8ce9f385f1bc7379633. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->